### PR TITLE
Add setting to make vanished players invulnerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Config option to make vanished players invulnerable
+
 ### Fixed
 - Hidden message command feedback
 - Wardens can smell vanished players

--- a/src/main/java/me/drex/vanish/command/VanishCommand.java
+++ b/src/main/java/me/drex/vanish/command/VanishCommand.java
@@ -72,11 +72,9 @@ public class VanishCommand {
             if (!VanishAPI.setVanish(target, vanish)) continue;
             if (src.getPlayerOrException() == target) {
                 src.sendSuccess(() -> Component.translatable(vanish ? "text.vanish.command.vanish.enable" : "text.vanish.command.vanish.disable"), false);
-                if (ConfigManager.vanish().invulnerable) target.setInvulnerable(true);
             } else {
                 src.sendSuccess(() -> Component.translatable(vanish ? "text.vanish.command.vanish.enable.other" : "text.vanish.command.vanish.disable.other", target.getDisplayName()), false);
                 target.sendSystemMessage(Component.translatable(vanish ? "text.vanish.command.vanish.enable" : "text.vanish.command.vanish.disable"));
-                if (ConfigManager.vanish().invulnerable) target.setInvulnerable(false);
             }
             result++;
         }

--- a/src/main/java/me/drex/vanish/command/VanishCommand.java
+++ b/src/main/java/me/drex/vanish/command/VanishCommand.java
@@ -72,9 +72,11 @@ public class VanishCommand {
             if (!VanishAPI.setVanish(target, vanish)) continue;
             if (src.getPlayerOrException() == target) {
                 src.sendSuccess(() -> Component.translatable(vanish ? "text.vanish.command.vanish.enable" : "text.vanish.command.vanish.disable"), false);
+                if (ConfigManager.vanish().invulnerable) target.setInvulnerable(true);
             } else {
                 src.sendSuccess(() -> Component.translatable(vanish ? "text.vanish.command.vanish.enable.other" : "text.vanish.command.vanish.disable.other", target.getDisplayName()), false);
                 target.sendSystemMessage(Component.translatable(vanish ? "text.vanish.command.vanish.enable" : "text.vanish.command.vanish.disable"));
+                if (ConfigManager.vanish().invulnerable) target.setInvulnerable(false);
             }
             result++;
         }

--- a/src/main/java/me/drex/vanish/config/VanishConfig.java
+++ b/src/main/java/me/drex/vanish/config/VanishConfig.java
@@ -19,7 +19,7 @@ public class VanishConfig {
     public boolean hideFromEntities = true;
 
     @Comment("Make vanished players invulnerable (Prevent deaths from tnt or other unforeseen accidents)")
-    public boolean invulnerable = true;
+    public boolean invulnerable = false;
 
     @Comment("Prevent vanished player world interactions")
     public Interaction interaction = new Interaction();

--- a/src/main/java/me/drex/vanish/config/VanishConfig.java
+++ b/src/main/java/me/drex/vanish/config/VanishConfig.java
@@ -18,6 +18,9 @@ public class VanishConfig {
     @Comment("Hide vanished players from entities, prevents hostile entities from targeting players, and more")
     public boolean hideFromEntities = true;
 
+    @Comment("Make vanished players invulnerable (Prevent deaths from tnt or other unforeseen accidents)")
+    public boolean invulnerable = true;
+
     @Comment("Prevent vanished player world interactions")
     public Interaction interaction = new Interaction();
 

--- a/src/main/java/me/drex/vanish/mixin/PlayerMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/PlayerMixin.java
@@ -1,0 +1,21 @@
+package me.drex.vanish.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Player.class)
+public abstract class PlayerMixin {
+
+    @ModifyReturnValue(method = "isInvulnerableTo", at = @At("RETURN"))
+    private boolean vanish_invulnerablePlayers(boolean original) {
+        if (ConfigManager.vanish().invulnerable && VanishAPI.isVanished((Player) (Object) this)) {
+            return true;
+        }
+        return original;
+    }
+
+}

--- a/src/main/resources/vanish.mixins.json
+++ b/src/main/resources/vanish.mixins.json
@@ -19,6 +19,7 @@
     "MinecraftServerMixin",
     "PlayerAdvancementsMixin",
     "PlayerListMixin",
+    "PlayerMixin",
     "ServerCommonPacketListenerImplMixin",
     "ServerGamePacketListenerImplMixin",
     "ServerLevelMixin",


### PR DESCRIPTION
This is useful if vanished players are not in creative mode and you want to prevent them from getting blown up.
- I use this for a more restricted spectator mode

Let me know if anything needs adjusting, Cheers!