### PR TITLE
Add setting to disable World interaction 

### DIFF
--- a/src/main/java/me/drex/vanish/config/VanishConfig.java
+++ b/src/main/java/me/drex/vanish/config/VanishConfig.java
@@ -42,6 +42,8 @@ public class VanishConfig {
         @Comment("Prevent entity pickups (arrows, experience orbs, items and tridents)")
         public boolean entityPickup = true;
 
+        @Comment("Prevent world interactions - As if player was in spawn protected area (attacking, breaking blocks, armour stand, chests, riding entity, etc)")
+        public boolean worldInteractions = false;
     }
 
 }

--- a/src/main/java/me/drex/vanish/mixin/ServerLevelMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ServerLevelMixin.java
@@ -3,16 +3,21 @@ package me.drex.vanish.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockDestructionPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerLevel.class)
 public abstract class ServerLevelMixin {
@@ -35,4 +40,8 @@ public abstract class ServerLevelMixin {
         }
     }
 
+    @Inject(method = "mayInteract", at = @At("HEAD"), cancellable = true)
+    private void vanish_disableInteract(Player player, BlockPos blockPos, CallbackInfoReturnable<Boolean> cir) {
+        if (VanishAPI.isVanished(player) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(false);
+    }
 }

--- a/src/main/java/me/drex/vanish/mixin/ServerPlayerMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ServerPlayerMixin.java
@@ -3,13 +3,18 @@ package me.drex.vanish.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerPlayer.class)
@@ -64,4 +69,18 @@ public abstract class ServerPlayerMixin {
         }
     }
 
+    @Inject(method = "attack", at = @At("HEAD"), cancellable = true)
+    private void vanish_stopAttack(Entity entity, CallbackInfo ci) {
+        if (VanishAPI.isVanished((ServerPlayer) (Object) this) && ConfigManager.vanish().interaction.worldInteractions) ci.cancel();
+    }
+
+    @Inject(method = "mayInteract", at = @At("HEAD"), cancellable = true)
+    private void vanish_stopInteract(Level level, BlockPos blockPos, CallbackInfoReturnable<Boolean> cir) {
+        if (VanishAPI.isVanished((ServerPlayer) (Object) this) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(false);
+    }
+
+    @Inject(method = "startRiding", at = @At("HEAD"), cancellable = true)
+    private void vanish_stopRide(Entity entity, boolean bl, CallbackInfoReturnable<Boolean> cir) {
+        if (VanishAPI.isVanished((ServerPlayer) (Object) this) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(false);
+    }
 }

--- a/src/main/java/me/drex/vanish/mixin/interaction/AbstractHorseMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/interaction/AbstractHorseMixin.java
@@ -1,0 +1,21 @@
+package me.drex.vanish.mixin.interaction;
+
+import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AbstractHorse.class)
+public class AbstractHorseMixin {
+
+    @Inject(method = "mobInteract", at = @At("HEAD"), cancellable = true)
+    private void vanish_disableMobInteract(Player player, InteractionHand interactionHand, CallbackInfoReturnable<InteractionResult> cir) {
+        if (VanishAPI.isVanished(player) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(InteractionResult.PASS);
+    }
+}

--- a/src/main/java/me/drex/vanish/mixin/interaction/ArmorStandMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/interaction/ArmorStandMixin.java
@@ -1,0 +1,22 @@
+package me.drex.vanish.mixin.interaction;
+
+import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ArmorStand.class)
+public class ArmorStandMixin {
+
+    @Inject(method = "interactAt", at = @At("HEAD"), cancellable = true)
+    private void vanish_disableInteraction(Player player, Vec3 vec3, InteractionHand interactionHand, CallbackInfoReturnable<InteractionResult> cir) {
+        if (VanishAPI.isVanished(player) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(InteractionResult.PASS);
+    }
+}

--- a/src/main/java/me/drex/vanish/mixin/interaction/CamelMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/interaction/CamelMixin.java
@@ -1,0 +1,21 @@
+package me.drex.vanish.mixin.interaction;
+
+import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.animal.camel.Camel;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Camel.class)
+public class CamelMixin {
+
+    @Inject(method = "mobInteract", at = @At("HEAD"), cancellable = true)
+    private void vanish_disableMobInteract(Player player, InteractionHand interactionHand, CallbackInfoReturnable<InteractionResult> cir) {
+        if (VanishAPI.isVanished(player) && ConfigManager.vanish().interaction.worldInteractions) cir.setReturnValue(InteractionResult.PASS);
+    }
+}

--- a/src/main/resources/vanish.mixins.json
+++ b/src/main/resources/vanish.mixins.json
@@ -26,10 +26,14 @@
     "SleepStatusMixin",
     "WardenMixin",
     "compat.expandedstorage.ContainerMixin",
+    "interaction.AbstractHorseMixin",
+    "interaction.ArmorStandMixin",
+    "interaction.CamelMixin",
     "interaction.EntitySelectorMixin",
     "interaction.FallOnBlockMixin",
     "interaction.InsideBlockMixin",
     "interaction.PlayerMixin",
+    "interaction.ServerLevelMixin",
     "interaction.StepOnBlockMixin",
     "interaction.VibrationSystemMixin"
   ]

--- a/src/main/resources/vanish.mixins.json
+++ b/src/main/resources/vanish.mixins.json
@@ -33,7 +33,6 @@
     "interaction.FallOnBlockMixin",
     "interaction.InsideBlockMixin",
     "interaction.PlayerMixin",
-    "interaction.ServerLevelMixin",
     "interaction.StepOnBlockMixin",
     "interaction.VibrationSystemMixin"
   ]


### PR DESCRIPTION
Adds a setting (Off by default) that makes the vanished player act like they were in spawn chunks + a few extra restrictions such as:
- Attacking entities
- Entity inventories
- Armor Stands
- Riding Entities

Once again, I use this for my restricted spectator mode. Super handy! 

I'm sure there's gotta be some interactions I've missed, let me know if you think of more to add. Also if I need to change anything, Cheers!