### PR TITLE
Fix containers remaining open by vanished player in certain conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Containers remaining open by vanished players in certain conditions
+
 ## [1.5.6] - 2024-06-20
 ### Added
 - Prevent advancement progress config option

--- a/src/main/java/me/drex/vanish/mixin/ContainerOpenersCountMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ContainerOpenersCountMixin.java
@@ -1,0 +1,24 @@
+package me.drex.vanish.mixin;
+
+import me.drex.vanish.api.VanishAPI;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.ContainerOpenersCounter;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.function.Predicate;
+
+@Mixin(ContainerOpenersCounter.class)
+public class ContainerOpenersCountMixin {
+    @ModifyArg(
+            method = "getPlayersWithContainerOpen",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/level/entity/EntityTypeTest;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"),
+            index = 2
+    )
+    private Predicate<Player> vanish_cancelCountChange(Predicate<Player> predicate) {
+        return predicate.and(player -> !VanishAPI.isVanished(player));
+    }
+}

--- a/src/main/java/me/drex/vanish/mixin/ContainerOpenersCountMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ContainerOpenersCountMixin.java
@@ -18,7 +18,7 @@ public class ContainerOpenersCountMixin {
                     target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/level/entity/EntityTypeTest;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"),
             index = 2
     )
-    private Predicate<Player> vanish_cancelCountChange(Predicate<Player> predicate) {
+    private Predicate<Player> vanish_excludeVanished(Predicate<Player> predicate) {
         return predicate.and(player -> !VanishAPI.isVanished(player));
     }
 }

--- a/src/main/resources/vanish.mixins.json
+++ b/src/main/resources/vanish.mixins.json
@@ -10,6 +10,7 @@
   "mixins": [
     "CommandSourceStackMixin",
     "ContainerMixin",
+    "ContainerOpenersCountMixin",
     "EntityGetterMixin",
     "EntityMixin",
     "EntitySelectorMixin",


### PR DESCRIPTION
Non-shulkerbox containers call `ContainerOpenersCounter#recheckOpeners`, which wasn't accounted for. This means that a Chest (any kind) or a Barrel that was at some point accessed by both visible and invisible players at the same time will remain open until every player, including the vanished ones, closes its GUI.

I'm not sure whether I should also test if the player is a `ServerPlayer` in the newly added mixin.