### PR TITLE
fix: waypoint visible from vanish players in spectator mode

### DIFF
--- a/src/main/java/me/drex/vanish/mixin/ServerWaypointManagerMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ServerWaypointManagerMixin.java
@@ -1,0 +1,41 @@
+package me.drex.vanish.mixin;
+
+//? >= 1.21.10 {
+import com.google.common.collect.Table;
+import me.drex.vanish.api.VanishAPI;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.waypoints.ServerWaypointManager;
+import net.minecraft.world.waypoints.WaypointTransmitter;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerWaypointManager.class)
+public abstract class ServerWaypointManagerMixin {
+
+    @Shadow
+    @Final
+    private Table<ServerPlayer, WaypointTransmitter, WaypointTransmitter.Connection> connections;
+
+    @Inject(method = "createConnection", at = @At("HEAD"), cancellable = true)
+    private void createConnection(ServerPlayer serverPlayer, WaypointTransmitter waypointTransmitter, CallbackInfo ci) {
+        if (waypointTransmitter instanceof ServerPlayer target
+                && !VanishAPI.canSeePlayer(target, serverPlayer)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "updateConnection", at = @At("HEAD"), cancellable = true)
+    private void updateConnection(ServerPlayer serverPlayer, WaypointTransmitter waypointTransmitter, WaypointTransmitter.Connection connection, CallbackInfo ci) {
+        if (waypointTransmitter instanceof ServerPlayer target
+                && !VanishAPI.canSeePlayer(target, serverPlayer)) {
+            this.connections.remove(serverPlayer, waypointTransmitter);
+            connection.disconnect();
+            ci.cancel();
+        }
+    }
+}
+//?}

--- a/src/main/resources/vanish.mixins.json
+++ b/src/main/resources/vanish.mixins.json
@@ -29,6 +29,7 @@
     "ServerCommonPacketListenerImplMixin",
     "ServerGamePacketListenerImplMixin",
     "ServerLevelMixin",
+    "ServerWaypointManagerMixin",
     "SleepStatusMixin",
     "VanishedServerPlayerMixin",
     "WardenMixin",


### PR DESCRIPTION
When a player is in spectator mode, they can still see the vanished player in the waypoint bar.
I tested this on version 1.21.10.

We may need to review additional calls to ``serverPlayer.isSpectator()`` to identify any other occurrences.

Current version:
https://i.wuffy.eu/u/engkqr.gif

Fixed version:
https://i.wuffy.eu/u/dXZ3VJ.gif

I just tested this fix with two players!