### PR TITLE
feat: hide join/quit message for vanished players

### DIFF
--- a/src/main/java/me/drex/vanish/mixin/PlayerListMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/PlayerListMixin.java
@@ -6,6 +6,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import eu.pb4.playerdata.api.PlayerDataApi;
 import me.drex.vanish.api.VanishAPI;
 import me.drex.vanish.api.VanishEvents;
+import me.drex.vanish.config.ConfigManager;
 import me.drex.vanish.util.Arguments;
 import me.drex.vanish.util.VanishData;
 import me.drex.vanish.util.VanishedEntity;
@@ -61,7 +62,9 @@ public abstract class PlayerListMixin {
     )
     public void hideJoinMessage(PlayerList playerList, Component component, boolean bl, Operation<Void> original, Connection connection, ServerPlayer actor) {
         if (VanishAPI.isVanished(actor)) {
-            VanishAPI.broadcastHiddenMessage(actor, component);
+            if (ConfigManager.vanish().sendJoinDisconnectMessage) {
+                VanishAPI.broadcastHiddenMessage(actor, component);
+            }
         } else {
             original.call(playerList, component, bl);
         }

--- a/src/main/java/me/drex/vanish/mixin/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/me/drex/vanish/mixin/ServerGamePacketListenerImplMixin.java
@@ -3,6 +3,7 @@ package me.drex.vanish.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.drex.vanish.api.VanishAPI;
+import me.drex.vanish.config.ConfigManager;
 import me.drex.vanish.util.Arguments;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
@@ -35,7 +36,9 @@ public abstract class ServerGamePacketListenerImplMixin {
     )
     public void hideLeaveMessage(PlayerList playerList, Component component, boolean bl, Operation<Void> original) {
         if (VanishAPI.isVanished(this.player)) {
-            VanishAPI.broadcastHiddenMessage(this.player, component);
+            if (ConfigManager.vanish().sendJoinDisconnectMessage) {
+                VanishAPI.broadcastHiddenMessage(this.player, component);
+            }
         } else {
             original.call(playerList, component, bl);
         }


### PR DESCRIPTION
Make it possible to disable the join/quit messages for vanished players.
It’s currently possible to suppress the join and quit message when toggling vanish, but not the actual join/quit messages.